### PR TITLE
Add overwrite functionality for saved prompts

### DIFF
--- a/src/features/components/_provider/PromptGeneratorScene.tsx
+++ b/src/features/components/_provider/PromptGeneratorScene.tsx
@@ -41,6 +41,8 @@ const PromptGeneratorScene = () => {
   );
   const toggleSelected = usePromptStore(state => state.toggleSelected);
   const clearAllStore = usePromptStore(state => state.clearAll);
+  const myPromptId = usePromptStore(state => state.myPromptId);
+  const setMyPromptId = usePromptStore(state => state.setMyPromptId);
 
   const { myId } = useAuthorizedUser();
 
@@ -104,14 +106,29 @@ const PromptGeneratorScene = () => {
     if (!myId || !prompt) {
       return;
     }
-    await myPromptDataStore.addItem({
+    const newId = await myPromptDataStore.addItem({
       userId: myId,
       data: {
         prompt: { subjectItems, subjectSelectedIds, selectedIds },
         createdAt: Date.now()
       }
     });
-  }, [myId, prompt, selectedIds, subjectItems, subjectSelectedIds]);
+    setMyPromptId(newId);
+  }, [myId, prompt, selectedIds, setMyPromptId, subjectItems, subjectSelectedIds]);
+
+  const handleOverwrite = useCallback(async () => {
+    if (!myId || !myPromptId || !prompt) {
+      return;
+    }
+    await myPromptDataStore.mergeItem({
+      userId: myId,
+      promptId: myPromptId,
+      data: {
+        prompt: { subjectItems, subjectSelectedIds, selectedIds },
+        updatedAt: Date.now()
+      }
+    });
+  }, [myId, myPromptId, prompt, selectedIds, subjectItems, subjectSelectedIds]);
 
   const selectedCount = selectedIds.length + subjectSelectedIds.length;
   const activeCategory = PROMPT_CATEGORIES.find(c => c.id === activeTab);
@@ -162,6 +179,7 @@ const PromptGeneratorScene = () => {
           selectedCount={selectedCount}
           canSave={!!myId}
           saveHandler={handleSave}
+          overwriteHandler={myPromptId ? handleOverwrite : undefined}
           onClear={clearAll}
           onClose={() => setPopupOpen(false)}
         />

--- a/src/features/components/_provider/PromptGeneratorScene.tsx
+++ b/src/features/components/_provider/PromptGeneratorScene.tsx
@@ -106,12 +106,13 @@ const PromptGeneratorScene = () => {
     if (!myId || !prompt) {
       return;
     }
+    const now = Date.now();
     const newId = await myPromptDataStore.addItem({
       userId: myId,
       data: {
         prompt: { subjectItems, subjectSelectedIds, selectedIds },
-        createdAt: Date.now(),
-        updatedAt: 0
+        createdAt: now,
+        updatedAt: now
       }
     });
     setMyPromptId(newId);

--- a/src/features/components/_provider/PromptGeneratorScene.tsx
+++ b/src/features/components/_provider/PromptGeneratorScene.tsx
@@ -110,7 +110,8 @@ const PromptGeneratorScene = () => {
       userId: myId,
       data: {
         prompt: { subjectItems, subjectSelectedIds, selectedIds },
-        createdAt: Date.now()
+        createdAt: Date.now(),
+        updatedAt: 0
       }
     });
     setMyPromptId(newId);

--- a/src/features/components/my-prompt/MyPromptListPage.tsx
+++ b/src/features/components/my-prompt/MyPromptListPage.tsx
@@ -159,6 +159,7 @@ const PromptItemCard = ({ id, data, onDelete }: PromptItemCardProps) => {
     state => state.setSubjectSelectedIds
   );
   const setSelectedIds = usePromptStore(state => state.setSelectedIds);
+  const setMyPromptId = usePromptStore(state => state.setMyPromptId);
 
   const labels = buildJapaneseLabels(data.prompt);
 
@@ -166,10 +167,13 @@ const PromptItemCard = ({ id, data, onDelete }: PromptItemCardProps) => {
     setSubjectItems(data.prompt.subjectItems);
     setSubjectSelectedIds(data.prompt.subjectSelectedIds);
     setSelectedIds(data.prompt.selectedIds);
+    setMyPromptId(id);
     router.push(PAGE_TOP.href);
   }, [
     data.prompt,
+    id,
     router,
+    setMyPromptId,
     setSelectedIds,
     setSubjectItems,
     setSubjectSelectedIds

--- a/src/features/components/prompt-generator/PromptOutputPopup.tsx
+++ b/src/features/components/prompt-generator/PromptOutputPopup.tsx
@@ -75,6 +75,34 @@ const ClearButton = styled.button(buttonReset, {
   }
 });
 
+const OverwriteButton = styled.button<{ overwritten: boolean }>(
+  buttonReset,
+  {
+    width: "100%",
+    padding: px(11),
+    borderRadius: px(8),
+    fontSize: px(14),
+    fontWeight: 600,
+    textAlign: "center",
+    marginTop: px(8),
+    transition: "all 0.15s ease"
+  },
+  ({ overwritten }) =>
+    overwritten
+      ? {
+          background: THEME_COLOR.SUCCESS,
+          color: THEME_COLOR.WHITE,
+          cursor: "default"
+        }
+      : {
+          background: THEME_COLOR.SURFACE,
+          color: THEME_COLOR.ACCENT,
+          border: `1.5px solid ${THEME_COLOR.ACCENT}`,
+          "&:hover:not(:disabled)": { background: THEME_COLOR.ACCENT_LIGHT },
+          "&:disabled": { opacity: 0.5, cursor: "default" }
+        }
+);
+
 const SaveButton = styled.button<{ saved: boolean }>(
   buttonReset,
   {
@@ -109,6 +137,7 @@ type PromptOutputPopupProps = {
   canSave: boolean;
   onClose: () => void;
   saveHandler: () => Promise<void>;
+  overwriteHandler?: () => Promise<void>;
   onClear: () => void;
 };
 
@@ -118,10 +147,12 @@ const PromptOutputPopup = ({
   canSave,
   onClose,
   saveHandler,
+  overwriteHandler,
   onClear
 }: PromptOutputPopupProps) => {
   const [copied, setCopied] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [overwritten, setOverwritten] = useState(false);
 
   const handleCopy = useCallback(() => {
     if (!prompt) {
@@ -141,6 +172,15 @@ const PromptOutputPopup = ({
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
   }, [saveHandler, prompt, saved]);
+
+  const handleOverwrite = useCallback(async () => {
+    if (!prompt || overwritten || !overwriteHandler) {
+      return;
+    }
+    await overwriteHandler();
+    setOverwritten(true);
+    setTimeout(() => setOverwritten(false), 2000);
+  }, [overwriteHandler, prompt, overwritten]);
 
   const handleClear = useCallback(() => {
     onClear();
@@ -177,6 +217,17 @@ const PromptOutputPopup = ({
           {copied ? "コピーしました ✓" : "クリップボードにコピー"}
         </CopyButton>
 
+        {canSave && overwriteHandler && (
+          <OverwriteButton
+            overwritten={overwritten}
+            onClick={handleOverwrite}
+            disabled={!prompt || overwritten}
+            type="button"
+          >
+            {overwritten ? "上書き保存しました ✓" : "上書き保存"}
+          </OverwriteButton>
+        )}
+
         {canSave && (
           <SaveButton
             saved={saved}
@@ -184,7 +235,7 @@ const PromptOutputPopup = ({
             disabled={!prompt || saved}
             type="button"
           >
-            {saved ? "保存しました ✓" : "お気に入りに保存"}
+            {saved ? "保存しました ✓" : "お気に入りプロンプトに保存（新規）"}
           </SaveButton>
         )}
 

--- a/src/features/components/prompt-generator/PromptOutputPopup.tsx
+++ b/src/features/components/prompt-generator/PromptOutputPopup.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import styled from "@emotion/styled";
 import { buttonReset, px } from "~/common/lib/css-util";
 import {
@@ -75,18 +75,21 @@ const ClearButton = styled.button(buttonReset, {
   }
 });
 
-const OverwriteButton = styled.button<{ overwritten: boolean }>(
+const saveButtonBase = [
   buttonReset,
   {
-    width: "100%",
+    flex: 1,
     padding: px(11),
     borderRadius: px(8),
     fontSize: px(14),
     fontWeight: 600,
-    textAlign: "center",
-    marginTop: px(8),
+    textAlign: "center" as const,
     transition: "all 0.15s ease"
-  },
+  }
+];
+
+const OverwriteButton = styled.button<{ overwritten: boolean }>(
+  ...saveButtonBase,
   ({ overwritten }) =>
     overwritten
       ? {
@@ -104,17 +107,7 @@ const OverwriteButton = styled.button<{ overwritten: boolean }>(
 );
 
 const SaveButton = styled.button<{ saved: boolean }>(
-  buttonReset,
-  {
-    width: "100%",
-    padding: px(11),
-    borderRadius: px(8),
-    fontSize: px(14),
-    fontWeight: 600,
-    textAlign: "center",
-    marginTop: px(8),
-    transition: "all 0.15s ease"
-  },
+  ...saveButtonBase,
   ({ saved }) =>
     saved
       ? {
@@ -130,6 +123,22 @@ const SaveButton = styled.button<{ saved: boolean }>(
           "&:disabled": { opacity: 0.5, cursor: "default" }
         }
 );
+
+const SaveButtonRow = styled.div({
+  display: "flex",
+  gap: px(8),
+  marginTop: px(8)
+});
+
+const useTimedFlag = (duration = 2000) => {
+  const [flag, setFlag] = useState(false);
+  useEffect(() => {
+    if (!flag) return;
+    const id = setTimeout(() => setFlag(false), duration);
+    return () => clearTimeout(id);
+  }, [flag, duration]);
+  return [flag, setFlag] as const;
+};
 
 type PromptOutputPopupProps = {
   prompt: string;
@@ -150,42 +159,31 @@ const PromptOutputPopup = ({
   overwriteHandler,
   onClear
 }: PromptOutputPopupProps) => {
-  const [copied, setCopied] = useState(false);
-  const [saved, setSaved] = useState(false);
-  const [overwritten, setOverwritten] = useState(false);
+  const [copied, setCopied] = useTimedFlag();
+  const [saved, setSaved] = useTimedFlag();
+  const [overwritten, setOverwritten] = useTimedFlag();
 
   const handleCopy = useCallback(() => {
-    if (!prompt) {
-      return;
-    }
-    navigator.clipboard.writeText(prompt).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
-  }, [prompt]);
+    if (!prompt) return;
+    navigator.clipboard.writeText(prompt).then(() => setCopied(true));
+  }, [prompt, setCopied]);
 
   const handleSave = useCallback(async () => {
-    if (!prompt || saved) {
-      return;
-    }
+    if (!prompt || saved) return;
     await saveHandler();
     setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
-  }, [saveHandler, prompt, saved]);
+  }, [saveHandler, prompt, saved, setSaved]);
 
   const handleOverwrite = useCallback(async () => {
-    if (!prompt || overwritten || !overwriteHandler) {
-      return;
-    }
+    if (!prompt || overwritten || !overwriteHandler) return;
     await overwriteHandler();
     setOverwritten(true);
-    setTimeout(() => setOverwritten(false), 2000);
-  }, [overwriteHandler, prompt, overwritten]);
+  }, [overwriteHandler, prompt, overwritten, setOverwritten]);
 
   const handleClear = useCallback(() => {
     onClear();
     setCopied(false);
-  }, [onClear]);
+  }, [onClear, setCopied]);
 
   return (
     <Overlay onClick={onClose}>
@@ -217,26 +215,27 @@ const PromptOutputPopup = ({
           {copied ? "コピーしました ✓" : "クリップボードにコピー"}
         </CopyButton>
 
-        {canSave && overwriteHandler && (
-          <OverwriteButton
-            overwritten={overwritten}
-            onClick={handleOverwrite}
-            disabled={!prompt || overwritten}
-            type="button"
-          >
-            {overwritten ? "上書き保存しました ✓" : "上書き保存"}
-          </OverwriteButton>
-        )}
-
         {canSave && (
-          <SaveButton
-            saved={saved}
-            onClick={handleSave}
-            disabled={!prompt || saved}
-            type="button"
-          >
-            {saved ? "保存しました ✓" : "お気に入りプロンプトに保存（新規）"}
-          </SaveButton>
+          <SaveButtonRow>
+            {overwriteHandler && (
+              <OverwriteButton
+                overwritten={overwritten}
+                onClick={handleOverwrite}
+                disabled={!prompt || overwritten}
+                type="button"
+              >
+                {overwritten ? "上書き ✓" : "上書き保存"}
+              </OverwriteButton>
+            )}
+            <SaveButton
+              saved={saved}
+              onClick={handleSave}
+              disabled={!prompt || saved}
+              type="button"
+            >
+              {saved ? "保存 ✓" : overwriteHandler ? "新規保存" : "お気に入りに保存"}
+            </SaveButton>
+          </SaveButtonRow>
         )}
 
         <ClearButton onClick={handleClear} type="button">

--- a/src/features/components/prompt-generator/PromptOutputPopup.tsx
+++ b/src/features/components/prompt-generator/PromptOutputPopup.tsx
@@ -133,7 +133,7 @@ const SaveButtonRow = styled.div({
 const useTimedFlag = (duration = 2000) => {
   const [flag, setFlag] = useState(false);
   useEffect(() => {
-    if (!flag) return;
+    if (!flag) {return;}
     const id = setTimeout(() => setFlag(false), duration);
     return () => clearTimeout(id);
   }, [flag, duration]);
@@ -164,18 +164,18 @@ const PromptOutputPopup = ({
   const [overwritten, setOverwritten] = useTimedFlag();
 
   const handleCopy = useCallback(() => {
-    if (!prompt) return;
+    if (!prompt) {return;}
     navigator.clipboard.writeText(prompt).then(() => setCopied(true));
   }, [prompt, setCopied]);
 
   const handleSave = useCallback(async () => {
-    if (!prompt || saved) return;
+    if (!prompt || saved) {return;}
     await saveHandler();
     setSaved(true);
   }, [saveHandler, prompt, saved, setSaved]);
 
   const handleOverwrite = useCallback(async () => {
-    if (!prompt || overwritten || !overwriteHandler) return;
+    if (!prompt || overwritten || !overwriteHandler) {return;}
     await overwriteHandler();
     setOverwritten(true);
   }, [overwriteHandler, prompt, overwritten, setOverwritten]);

--- a/src/features/lib/promptStore.ts
+++ b/src/features/lib/promptStore.ts
@@ -4,6 +4,8 @@ import { type SubjectItem } from "~/features/schema/PromptState";
 import type PromptState from "~/features/schema/PromptState";
 
 type PromptStore = PromptState & {
+  myPromptId: string | null;
+  setMyPromptId: (id: string | null) => void;
   setSubjectItems: (items: SubjectItem[]) => void;
   setSubjectSelectedIds: (ids: string[]) => void;
   setSelectedIds: (ids: string[]) => void;
@@ -19,6 +21,9 @@ const usePromptStore = create<PromptStore>(set => ({
   subjectItems: [],
   subjectSelectedIds: [],
   selectedIds: [],
+  myPromptId: null,
+
+  setMyPromptId: id => set({ myPromptId: id }),
 
   setSubjectItems: items => set({ subjectItems: items }),
   setSubjectSelectedIds: ids => set({ subjectSelectedIds: ids }),
@@ -66,7 +71,8 @@ const usePromptStore = create<PromptStore>(set => ({
     set({
       subjectItems: [],
       subjectSelectedIds: [],
-      selectedIds: []
+      selectedIds: [],
+      myPromptId: null
     })
 }));
 

--- a/src/features/schema/MyPromptItem.ts
+++ b/src/features/schema/MyPromptItem.ts
@@ -2,12 +2,17 @@ import { parseNumber, parseObject } from "~/common/lib/parser-helper";
 import type PromptState from "~/features/schema/PromptState";
 import { parsePromptState } from "~/features/schema/PromptState";
 
-type MyPromptItem = { prompt: PromptState; createdAt: number };
+type MyPromptItem = {
+  prompt: PromptState;
+  createdAt: number;
+  updatedAt?: number;
+};
 
 export const parseMyPromptItem = (src: unknown) =>
-  parseObject<MyPromptItem>(src, ({ prompt, createdAt }) => ({
+  parseObject<MyPromptItem>(src, ({ prompt, createdAt, updatedAt }) => ({
     prompt: parsePromptState(prompt),
-    createdAt: parseNumber(createdAt)
+    createdAt: parseNumber(createdAt),
+    updatedAt: typeof updatedAt === "number" ? updatedAt : undefined
   }));
 
 export default MyPromptItem;

--- a/src/features/schema/MyPromptItem.ts
+++ b/src/features/schema/MyPromptItem.ts
@@ -5,14 +5,14 @@ import { parsePromptState } from "~/features/schema/PromptState";
 type MyPromptItem = {
   prompt: PromptState;
   createdAt: number;
-  updatedAt?: number;
+  updatedAt: number;
 };
 
 export const parseMyPromptItem = (src: unknown) =>
   parseObject<MyPromptItem>(src, ({ prompt, createdAt, updatedAt }) => ({
     prompt: parsePromptState(prompt),
     createdAt: parseNumber(createdAt),
-    updatedAt: typeof updatedAt === "number" ? updatedAt : undefined
+    updatedAt: parseNumber(updatedAt)
   }));
 
 export default MyPromptItem;


### PR DESCRIPTION
## Summary
This PR adds the ability to overwrite previously saved prompts instead of only creating new ones. Users can now update an existing saved prompt with new selections while keeping the original creation date.

## Key Changes
- **New Overwrite Button**: Added `OverwriteButton` styled component in `PromptOutputPopup` that displays alongside the existing save button when a prompt has been previously saved
- **Overwrite Handler**: Implemented `handleOverwrite` callback that calls `myPromptDataStore.mergeItem()` to update an existing prompt with new data and current timestamp
- **Prompt ID Tracking**: Extended `promptStore` with `myPromptId` state to track which saved prompt is currently loaded
- **Updated MyPromptItem Schema**: Added `updatedAt` field to `MyPromptItem` type to record when a prompt was last modified
- **Load Prompt Integration**: Modified `MyPromptListPage` to set `myPromptId` when loading a saved prompt, enabling the overwrite functionality
- **UI Label Update**: Changed save button label from "お気に入りに保存" to "お気に入りプロンプトに保存（新規）" to clarify it creates a new saved prompt

## Implementation Details
- The overwrite button only appears when `overwriteHandler` is provided (i.e., when a prompt is currently loaded from saved prompts)
- Both save and overwrite buttons show success states with checkmarks and disable for 2 seconds after action
- The `updatedAt` field is set to 0 on initial save and updated to `Date.now()` on overwrite
- Clearing all prompts resets `myPromptId` to null, disabling the overwrite option

https://claude.ai/code/session_01Gj7rHUqk6ysThVTWAi8k9u