### PR TITLE
feat: ユーザーごとの翻訳API利用量をFirestoreに記録する

### DIFF
--- a/functions/src/module/translateWithApi.ts
+++ b/functions/src/module/translateWithApi.ts
@@ -1,10 +1,16 @@
 import { onCall } from "firebase-functions/v2/https";
-import { FieldValue } from "firebase-admin/firestore";
 import responseAppCallable from "@/local/responseAppCallable";
 import { getSecretParams, getSecretString } from "@/local/secret-manager";
 import { COMMON_CALLABLE_REGION } from "~/features/schema/AppCallableScheme";
 import AppError from "~/features/schema/AppError";
 import { firebaseFirestore } from "@/lib/firebase-app";
+import { ServerDataStoreAgent } from "@/lib/ServerDataStoreAgent";
+import { translationUsageDataStoreScheme } from "~/features/schema/app-data-store-scheme";
+
+const translationUsageAgent = new ServerDataStoreAgent(
+  firebaseFirestore,
+  translationUsageDataStoreScheme
+);
 
 const currentMonth = () => {
   const now = new Date();
@@ -40,17 +46,19 @@ export default onCall(
         translations: { text: string }[];
       };
 
-      const usageRef = firebaseFirestore()
-        .collection("profiles")
-        .doc(auth.uid)
-        .collection("translationUsage")
-        .doc(currentMonth());
-      await usageRef.set(
-        {
-          characterCount: FieldValue.increment(jaWord.length),
-          callCount: FieldValue.increment(1)
-        },
-        { merge: true }
+      const month = currentMonth();
+      await ServerDataStoreAgent.runTransaction(
+        firebaseFirestore,
+        ({ get }) => get(translationUsageAgent, { userId: auth.uid, month }),
+        (current, { set }) =>
+          set(translationUsageAgent, {
+            userId: auth.uid,
+            month,
+            data: {
+              characterCount: (current?.characterCount ?? 0) + jaWord.length,
+              callCount: (current?.callCount ?? 0) + 1
+            }
+          })
       );
 
       return {

--- a/functions/src/module/translateWithApi.ts
+++ b/functions/src/module/translateWithApi.ts
@@ -1,8 +1,17 @@
 import { onCall } from "firebase-functions/v2/https";
+import { FieldValue } from "firebase-admin/firestore";
 import responseAppCallable from "@/local/responseAppCallable";
 import { getSecretParams, getSecretString } from "@/local/secret-manager";
 import { COMMON_CALLABLE_REGION } from "~/features/schema/AppCallableScheme";
 import AppError from "~/features/schema/AppError";
+import { firebaseFirestore } from "@/lib/firebase-app";
+
+const currentMonth = () => {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  return `${y}-${m}`;
+};
 
 export default onCall(
   {
@@ -30,6 +39,20 @@ export default onCall(
       const json = (await res.json()) as {
         translations: { text: string }[];
       };
+
+      const usageRef = firebaseFirestore()
+        .collection("profiles")
+        .doc(auth.uid)
+        .collection("translationUsage")
+        .doc(currentMonth());
+      await usageRef.set(
+        {
+          characterCount: FieldValue.increment(jaWord.length),
+          callCount: FieldValue.increment(1)
+        },
+        { merge: true }
+      );
+
       return {
         case: "ok",
         data: { enWord: json.translations[0].text }

--- a/src/features/schema/TranslationUsage.ts
+++ b/src/features/schema/TranslationUsage.ts
@@ -1,0 +1,14 @@
+import { parseNumber, parseObject } from "~/common/lib/parser-helper";
+
+type TranslationUsage = {
+  characterCount: number;
+  callCount: number;
+};
+
+export const parseTranslationUsage = (src: unknown) =>
+  parseObject<TranslationUsage>(src, ({ characterCount, callCount }) => ({
+    characterCount: parseNumber(characterCount),
+    callCount: parseNumber(callCount)
+  }));
+
+export default TranslationUsage;

--- a/src/features/schema/app-data-store-scheme.ts
+++ b/src/features/schema/app-data-store-scheme.ts
@@ -3,6 +3,8 @@ import type MyPromptItem from "~/features/schema/MyPromptItem";
 import { parseMyPromptItem } from "~/features/schema/MyPromptItem";
 import type DummyProfile from "~/features/schema/DummyProfile";
 import { parseDummyProfile } from "~/features/schema/DummyProfile";
+import type TranslationUsage from "~/features/schema/TranslationUsage";
+import { parseTranslationUsage } from "~/features/schema/TranslationUsage";
 
 export const profileDataStoreScheme: DataStoreScheme<DummyProfile, "userId"> = {
   name: "profiles",
@@ -18,5 +20,16 @@ export const myPromptDataStoreScheme: DataStoreScheme<
   name: "myPrompts",
   parse: parseMyPromptItem,
   documentKey: "promptId",
+  parentCollection: profileDataStoreScheme
+};
+
+export const translationUsageDataStoreScheme: DataStoreScheme<
+  TranslationUsage,
+  "month",
+  "userId"
+> = {
+  name: "translationUsage",
+  parse: parseTranslationUsage,
+  documentKey: "month",
   parentCollection: profileDataStoreScheme
 };


### PR DESCRIPTION
翻訳実行時に profiles/{userId}/translationUsage/{YYYY-MM} ドキュメントへ
文字数(characterCount)と呼び出し回数(callCount)をFieldValue.incrementで
原子的に加算する。DeepLは文字数課金のためinput文字列長を記録単位とした。

https://claude.ai/code/session_01Nc5QMegF3T2q41gjWzDXUp